### PR TITLE
Add docs and CI workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assets/images/*.png filter=lfs diff=lfs merge=lfs -text
+assets/sounds/* filter=lfs diff=lfs merge=lfs -text

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+Describe the changes introduced by this pull request.
+
+## Checklist
+- [ ] Tests pass (`flake8`, `pytest`, `mypy`, `eslint`, `jest`)
+- [ ] Documentation updated if needed
+- [ ] Ready for review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest mypy
+
+      - name: Run flake8
+        run: flake8 src
+
+      - name: Run pytest
+        run: pytest
+
+      - name: Run mypy
+        run: mypy src
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx eslint .
+
+      - name: Run Jest
+        run: npx jest --ci --passWithNoTests
+
+      - name: Build Phaser project
+        run: npm run build
+
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+
+Examples of unacceptable behavior include:
+- Trolling, insulting or derogatory comments
+- Personal or political attacks
+
+## Enforcement
+
+Community leaders are responsible for clarifying standards of acceptable behavior
+and will take appropriate action in response to any behavior they deem
+inappropriate.
+
+Instances of abusive or unacceptable behavior may be reported by contacting the
+maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage].
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to SMaK
+
+Thank you for considering contributing to the project! We welcome issues and pull requests.
+
+## Issues
+- Search existing issues before opening a new one.
+- Provide clear steps to reproduce bugs and include relevant logs or screenshots.
+
+## Pull Requests
+- Create a descriptive branch name such as `feature/short-description` or `bugfix/issue-id`.
+- Keep PRs focused and small when possible.
+- Include tests for new functionality.
+- Run `flake8`, `pytest`, `mypy`, `eslint` and `jest` locally before submitting.
+
+## Coding Standards
+- Python code should follow PEP8 and pass `flake8` and `mypy`.
+- JavaScript code should pass `eslint` with the default configuration.
+
+## Review Process
+1. Open your pull request against the `main` branch.
+2. A maintainer will review and may request changes.
+3. Once approved, your PR will be squashed and merged.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ben Gothard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
-# smak Phaser Web Build
+# SMaK Game
 
-This repository contains a Phaser 3 web port of the `smak` game. All game
-graphics are generated at runtime so no binary image assets are required.
+SMaK is an open source arcade shooter written in Python with a Phaser 3 web port. The project started as a small prototype using Pygame and was later ported to run in the browser. All sprites are generated at runtime, allowing the repository to remain lightweight without binary assets.
 
-## Development
+## Getting Started
 
-1. Install dependencies:
+### Python / Pygame Prototype
+1. Install Python 3 and Pygame:
+   ```bash
+   pip install pygame
+   ```
+2. Launch the prototype:
+   ```bash
+   python src/main.py
+   ```
+
+### Phaser Web Build
+1. Install Node.js and dependencies:
    ```bash
    npm install
    ```
@@ -19,8 +29,15 @@ graphics are generated at runtime so no binary image assets are required.
    npm run build
    ```
 
-## GitHub Pages
+The contents of the `docs/` folder can be served via GitHub Pages. A live demo will be available at:
 
-This repository uses a GitHub Actions workflow to publish the contents of the
-`docs/` directory to the `gh-pages` branch. Enable GitHub Pages from that
-branch to serve the game online.
+<https://YOUR_GITHUB_USERNAME.github.io/smak>
+
+## Repository Layout
+- `src/` – Python source code for the prototype
+- `static/` – Phaser 3 assets and entry point
+- `assets/` – Placeholder directory for images and sounds
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,9 @@
+# Roadmap
+
+| Milestone | Features |
+|-----------|----------|
+| **v0.2**  | - Advanced AI behaviors<br>- Basic multiplayer support |
+| **v0.3**  | - Improved art pipeline<br>- Level editor tooling |
+| **v1.0**  | - Full online multiplayer<br>- Extensive campaign mode |
+
+These targets are aspirational and may shift as development progresses.


### PR DESCRIPTION
## Summary
- add project overview, setup and license
- add contributing, code of conduct and roadmap
- set up GitHub templates
- configure CI with Python and Node jobs
- track assets via LFS

## Testing
- `flake8 src` *(fails: E501 line too long)*
- `pytest -q`
- `mypy src` *(fails: missing pygame stubs)*
- `npm ci`
- `npx eslint .` *(fails: config not found)*
- `npx jest --ci --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849ec5c987c832a9d7cd0e3c853322c