### PR TITLE
Enable GitHub Pages build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 __pycache__/
 *.pyc
 node_modules/
-docs/

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ SMaK is an open source arcade shooter written in Python with a Phaser 3 web port
    npm start
    ```
 3. Open `http://localhost:8080` in your browser.
-4. Build the static site (optional):
+4. Build the static site (required for GitHub Pages):
    ```bash
    npm run build
    ```
 
-The contents of the `docs/` folder can be served via GitHub Pages. A live demo will be available at:
+This generates a `docs/` directory containing the static site. Commit this
+folder to your repository and enable **GitHub Pages** to serve from the `docs/`
+folder. The game will then be playable at:
 
 <https://YOUR_GITHUB_USERNAME.github.io/smak>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Smak Phaser</title>
+  <style>
+    body { margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <canvas id="gameCanvas"></canvas>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.js"></script>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,103 @@
+class Boot extends Phaser.Scene {
+  constructor() {
+    super('Boot');
+  }
+  preload() {
+    // Generate simple textures using graphics to avoid binary assets
+    const g = this.make.graphics({ x: 0, y: 0, add: false });
+    g.fillStyle(0x00ff00, 1);
+    g.fillRect(0, 0, 32, 32);
+    g.generateTexture('player', 32, 32);
+    g.clear();
+
+    g.fillStyle(0xff0000, 1);
+    g.fillRect(0, 0, 32, 32);
+    g.generateTexture('enemy', 32, 32);
+    g.clear();
+
+    g.fillStyle(0xffff00, 1);
+    g.fillRect(0, 0, 8, 8);
+    g.generateTexture('projectile', 8, 8);
+    g.destroy();
+  }
+  create() {
+    this.scene.start('Play');
+  }
+}
+
+class Play extends Phaser.Scene {
+  constructor() {
+    super('Play');
+    this.enemy = null;
+    this.projectiles = null;
+  }
+  create() {
+    this.cursors = this.input.keyboard.createCursorKeys();
+    this.space = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+
+    this.player = this.physics.add.sprite(400, 300, 'player');
+    this.player.setCollideWorldBounds(true);
+
+    this.enemy = this.physics.add.sprite(100, 100, 'enemy');
+    this.enemy.health = 3;
+
+    this.projectiles = this.physics.add.group();
+
+    this.physics.add.overlap(this.projectiles, this.enemy, this.hitEnemy, null, this);
+  }
+  hitEnemy(bullet, enemy) {
+    bullet.destroy();
+    enemy.health -= 1;
+    if (enemy.health <= 0) {
+      enemy.destroy();
+    }
+  }
+  update() {
+    if (this.cursors.left.isDown) {
+      this.player.setVelocityX(-160);
+    } else if (this.cursors.right.isDown) {
+      this.player.setVelocityX(160);
+    } else {
+      this.player.setVelocityX(0);
+    }
+
+    if (Phaser.Input.Keyboard.JustDown(this.space)) {
+      const bullet = this.projectiles.create(this.player.x, this.player.y, 'projectile');
+      bullet.setVelocityX(300);
+    }
+
+    if (this.enemy.active) {
+      if (this.player.x > this.enemy.x) {
+        this.enemy.setVelocityX(60);
+      } else if (this.player.x < this.enemy.x) {
+        this.enemy.setVelocityX(-60);
+      } else {
+        this.enemy.setVelocityX(0);
+      }
+    }
+
+    this.projectiles.children.each((b) => {
+      if (b.x > 800 || b.x < 0 || b.y > 600 || b.y < 0) {
+        b.destroy();
+      }
+    }, this);
+  }
+}
+
+const config = {
+  type: Phaser.CANVAS,
+  width: 800,
+  height: 600,
+  canvas: document.getElementById('gameCanvas'),
+  physics: {
+    default: 'arcade',
+    arcade: {
+      debug: false,
+    },
+  },
+  scene: [Boot, Play],
+};
+
+window.addEventListener('load', () => {
+  new Phaser.Game(config);
+});


### PR DESCRIPTION
## Summary
- include generated `docs` directory for GitHub Pages
- document how to build `docs/` and enable Pages
- allow `docs/` to be committed

## Testing
- `pip install -r requirements.txt`
- `flake8 src`
- `npm run lint:js` *(fails: 'Phaser' is not defined)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684ae049b98c832ab32ad6b5dfaa9578