### PR TITLE
Fix lint errors with Phaser global

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,3 +1,5 @@
+/* global Phaser */
+
 class Boot extends Phaser.Scene {
   constructor() {
     super('Boot');


### PR DESCRIPTION
## Summary
- declare Phaser as a global to satisfy ESLint

## Testing
- `npm run lint:js`
- `npm run lint:py` *(fails: flake8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1cd88e0832a819da92d4d0ecc59