### PR TITLE
Sync runtime graphics across versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SMaK Game
 
-SMaK is an open source arcade shooter written in Python with a Phaser 3 web port. The project started as a small prototype using Pygame and was later ported to run in the browser. All sprites are generated at runtime, allowing the repository to remain lightweight without binary assets.
+SMaK is an open source arcade shooter written in Python with a Phaser 3 web port. The project started as a small prototype using Pygame and was later ported to run in the browser. **Both versions generate their sprites at runtime**, keeping the repository lightweight without binary assets.
 
 ## Getting Started
 

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -10,7 +10,9 @@ class Enemy:
 
     def __init__(self, x: int, y: int) -> None:
         """Load the enemy sprite and position it on screen."""
-        self.image = pygame.image.load("assets/images/enemy.png").convert_alpha()
+        # Create a red square sprite at runtime to avoid external files
+        self.image = pygame.Surface((32, 32), pygame.SRCALPHA)
+        self.image.fill((255, 0, 0))
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         self.speed = 2

--- a/src/player.py
+++ b/src/player.py
@@ -6,7 +6,9 @@ class Player:
 
     def __init__(self, x: int, y: int) -> None:
         """Load the player sprite and position it on screen."""
-        self.image = pygame.image.load("assets/images/player.png").convert_alpha()
+        # Create a simple green square so no external assets are required
+        self.image = pygame.Surface((32, 32), pygame.SRCALPHA)
+        self.image.fill((0, 255, 0))
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         # Allow the player to take damage like enemies

--- a/src/projectile.py
+++ b/src/projectile.py
@@ -6,7 +6,9 @@ class Projectile:
 
     def __init__(self, x: int, y: int, dx: float, dy: float, speed: int = 10, owner=None) -> None:
         """Create a projectile at (x, y) moving in (dx, dy) direction."""
-        self.image = pygame.image.load("assets/images/projectile.png").convert_alpha()
+        # Yellow square generated on the fly instead of loading an image
+        self.image = pygame.Surface((8, 8), pygame.SRCALPHA)
+        self.image.fill((255, 255, 0))
         self.rect = self.image.get_rect(center=(x, y))
         # Normalize direction and scale by speed
         magnitude = (dx ** 2 + dy ** 2) ** 0.5 or 1


### PR DESCRIPTION
## Summary
- generate sprites at runtime in Python prototype to remove asset dependencies
- clarify README that both versions use runtime-generated sprites

## Testing
- `flake8 src`
- `npm run lint:js`
- `npm run lint:py`


------
https://chatgpt.com/codex/tasks/task_e_684b1d61a4a4832aa4cfdbcd720e90e2