### PR TITLE
Remove version pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 'lts/*'
 
       - name: Install Node dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SMaK is an open source arcade shooter written in Python with a Phaser 3 web port
 ### Python / Pygame Prototype
 1. Install Python 3 and the required dependencies:
    ```bash
-   pip install -r requirements.txt
+   pip install pygame
    ```
 2. Launch the prototype:
    ```bash
@@ -16,9 +16,9 @@ SMaK is an open source arcade shooter written in Python with a Phaser 3 web port
 3. Watch enemies engage in a free-for-all battle where they also attack each other.
 
 ### Phaser Web Build
-1. Install Node.js and dependencies:
+1. Install Node.js LTS and dependencies:
    ```bash
-   npm install
+   npm ci
    ```
 2. Start the development server:
    ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Node.js LTS from distribution packages
+sudo apt-get update
+sudo apt-get install -y nodejs
+
+# Install Python dependencies
+python -m pip install --upgrade pip
+pip install pygame flake8
+
+# Install Node dependencies
+npm ci

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "lint:py": "flake8 src/"
   },
   "dependencies": {
-    "phaser": "^3.70.0"
+    "phaser": "latest"
   },
   "devDependencies": {
-    "http-server": "^14.1.1",
-    "eslint": "^8.57.0"
+    "http-server": "latest",
+    "eslint": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- use `latest` dependencies in package.json
- add a simple `install.sh` script
- reference Node.js LTS in CI and README

## Testing
- `flake8 src/`
- `pytest -q`
- `mypy`
- `npx eslint static/js --ext .js,.jsx`
- `npx jest --ci --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684b287e7e10832a8706965ea738bb0e