### PR TITLE
Fix ESLint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/
-docs/
-static/assets/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,29 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import js from "@eslint/js";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  {
+    ignores: ["node_modules/**", "docs/**", "static/assets/**"],
+  },
+  ...compat.config({
+    extends: "eslint:recommended",
+    env: {
+      browser: true,
+      node: true,
+      es2021: true,
+    },
+    parserOptions: {
+      ecmaVersion: 12,
+      sourceType: "module",
+    },
+    rules: {},
+  }),
+];


### PR DESCRIPTION
## Summary
- add an ESLint flat configuration
- remove obsolete `.eslintignore`

## Testing
- `npm run lint:js`
- `pip install -r requirements.txt`
- `python -m flake8 src/`
- `mypy`
- `pytest`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b30a25f18832abdf3711cadbdadd1