### PR TITLE
Fix projectile cleanup when enemy destroyed

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,8 @@ class Game:
                         if p in self.projectiles:
                             self.projectiles.remove(p)
                         if isinstance(t, Enemy) and t.health <= 0:
-                            self.enemies.remove(t)
+                            if t in self.enemies:
+                                self.enemies.remove(t)
                         elif isinstance(t, Player) and t.health <= 0:
                             self.running = False
                         break

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -82,6 +82,7 @@ class Play extends Phaser.Scene {
   hitEnemy(bullet, enemy) {
     if (bullet.getData('owner') === enemy) return;
     bullet.destroy();
+    if (!enemy.active) return;
     enemy.health -= 1;
     enemy.lastHit = this.time.now;
     enemy.lastRegen = enemy.lastHit;
@@ -92,6 +93,7 @@ class Play extends Phaser.Scene {
   hitPlayer(bullet, player) {
     if (bullet.getData('owner') === player) return;
     bullet.destroy();
+    if (!player.active) return;
     player.health -= 1;
     player.lastHit = this.time.now;
     player.lastRegen = player.lastHit;


### PR DESCRIPTION
## Summary
- prevent Python game from crashing when multiple bullets kill the same enemy
- guard against double-destruction of targets in the Phaser build

## Testing
- `flake8`
- `pytest -q`
- `mypy .`
- `npx eslint static/js`
- `npx jest --runInBand --passWithNoTests`
- `SDL_VIDEODRIVER=dummy python src/main.py` (started and exited without errors)


------
https://chatgpt.com/codex/tasks/task_e_684b4bdd6334832ab167ba900fa65c8b