### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ SMaK is an open source arcade shooter written in Python with a Phaser 3 web port
    npm run build
    ```
 
-This generates a `docs/` directory containing the static site. Commit this
-folder to your repository and enable **GitHub Pages** to serve from the `docs/`
-folder. The game will then be playable at:
+This generates a `docs/` directory containing the static site. The included
+GitHub Actions workflow automatically publishes this folder to the
+`gh-pages` branch, so you don't need to commit it manually. Enable
+**GitHub Pages** to serve from the `gh-pages` branch and the game will be
+playable at:
 
 <https://YOUR_GITHUB_USERNAME.github.io/smak>
 


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push to `gh-pages`
- clarify that the docs folder is automatically published

## Testing
- `flake8`
- `pytest`
- `mypy`
- `eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b51aee000832aaf6a30eb53c9a8d5