### PR TITLE
Fix CI pytest command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m flake8 src/
 
       - name: Run pytest
-        run: pytest
+        run: python -m pytest
 
       - name: Run mypy
         run: mypy


### PR DESCRIPTION
## Summary
- fix `pytest` invocation in CI workflow so the command is always available

## Testing
- `python -m flake8 src/`
- `python -m pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --ci --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b55952320832aaf3ac53cffd8d1e4