### PR TITLE
Fix projectile spawn to prevent accidental game end

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -29,6 +29,7 @@ class Boot extends Phaser.Scene {
 
 const GAME_WIDTH = 1024;
 const GAME_HEIGHT = 768;
+const PROJECTILE_SPAWN_OFFSET = 20;
 
 class Play extends Phaser.Scene {
   constructor() {
@@ -114,7 +115,13 @@ class Play extends Phaser.Scene {
         pointer.worldX,
         pointer.worldY,
       );
-      const bullet = this.projectiles.create(this.player.x, this.player.y, 'projectile');
+      const offsetX = Math.cos(angle) * PROJECTILE_SPAWN_OFFSET;
+      const offsetY = Math.sin(angle) * PROJECTILE_SPAWN_OFFSET;
+      const bullet = this.projectiles.create(
+        this.player.x + offsetX,
+        this.player.y + offsetY,
+        'projectile',
+      );
       bullet.setData('owner', this.player);
       bullet.setVelocity(Math.cos(angle) * 300, Math.sin(angle) * 300);
     }

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,8 @@ from projectile import Projectile
 
 # Number of enemies spawned at game start
 ENEMY_SPAWN_COUNT = 6
+# Distance in pixels to spawn projectiles in front of the shooter
+PROJECTILE_SPAWN_OFFSET = 20
 
 
 class Game:
@@ -43,7 +45,14 @@ class Game:
                 if event.key in (pygame.K_LSHIFT, pygame.K_RSHIFT):
                     x, y = self.player.rect.center
                     mx, my = pygame.mouse.get_pos()
-                    self.projectiles.append(Projectile(x, y, mx - x, my - y, owner=self.player))
+                    dx = mx - x
+                    dy = my - y
+                    mag = (dx ** 2 + dy ** 2) ** 0.5 or 1
+                    start_x = x + int(dx / mag * PROJECTILE_SPAWN_OFFSET)
+                    start_y = y + int(dy / mag * PROJECTILE_SPAWN_OFFSET)
+                    self.projectiles.append(
+                        Projectile(start_x, start_y, mx - x, my - y, owner=self.player)
+                    )
 
     def run(self):
         """Main game loop."""

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -36,6 +36,7 @@ const ENEMY_MAX_HEALTH = 10;
 const ENEMY_SPAWN_COUNT = 5;
 const REGEN_DELAY = 3000;
 const REGEN_INTERVAL = 1000;
+const PROJECTILE_SPAWN_OFFSET = 20;
 
 class Play extends Phaser.Scene {
   constructor() {
@@ -135,7 +136,13 @@ class Play extends Phaser.Scene {
         pointer.worldX,
         pointer.worldY,
       );
-      const bullet = this.projectiles.create(this.player.x, this.player.y, 'projectile');
+      const offsetX = Math.cos(angle) * PROJECTILE_SPAWN_OFFSET;
+      const offsetY = Math.sin(angle) * PROJECTILE_SPAWN_OFFSET;
+      const bullet = this.projectiles.create(
+        this.player.x + offsetX,
+        this.player.y + offsetY,
+        'projectile',
+      );
       bullet.setData('owner', this.player);
       bullet.setVelocity(Math.cos(angle) * 300, Math.sin(angle) * 300);
     }


### PR DESCRIPTION
## Summary
- add `PROJECTILE_SPAWN_OFFSET` constant
- spawn projectiles slightly ahead of the shooter in Python and Phaser code
- update built JS in `docs`

## Testing
- `flake8`
- `pytest`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b72faf07c832ab7e0ac47f537e4ab