### PR TITLE
Fix missing board before start

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -214,4 +214,6 @@ window.addEventListener('load', () => {
   document.getElementById('startBtn').addEventListener('click', startGame);
   document.getElementById('pauseBtn').addEventListener('click', pauseGame);
   document.getElementById('restartBtn').addEventListener('click', restartGame);
+  // Initialize the game board immediately so the canvas is visible
+  startGame();
 });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -258,4 +258,6 @@ window.addEventListener('load', () => {
   document.getElementById('startBtn').addEventListener('click', startGame);
   document.getElementById('pauseBtn').addEventListener('click', pauseGame);
   document.getElementById('restartBtn').addEventListener('click', restartGame);
+  // Initialize the game board immediately so the canvas is visible
+  startGame();
 });


### PR DESCRIPTION
## Summary
- make Phaser game start automatically so the board appears immediately

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b8f89d1f4832a97d6dd8f55229b22