### PR TITLE
Fix ESLint CLI flag

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 
 export default [
   {
+    files: ["**/*.js", "**/*.jsx"],
+  },
+  {
     ignores: ["node_modules/**", "docs/**", "static/assets/**"],
   },
   ...compat.config({

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "http-server -c-1 -a localhost -p 8080 ./static",
     "build": "rm -rf docs && cp -r static docs && touch docs/.nojekyll",
-    "lint:js": "eslint static/js --ext .js,.jsx",
+    "lint:js": "eslint static/js",
     "lint:py": "flake8 src/"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- remove deprecated `--ext` flag from `lint:js` script
- let ESLint config define JS/JSX file patterns

## Testing
- `pip install -q -r requirements.txt`
- `python -m flake8 src/`
- `python -m pytest`
- `mypy`
- `npx eslint static/js`
- `npx jest --ci --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b95f0c2dc832ab7b73b1c634b9362