### PR TITLE
Fix projectile self-hit from shift-shoot

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -29,7 +29,7 @@ class Boot extends Phaser.Scene {
 
 const GAME_WIDTH = 1024;
 const GAME_HEIGHT = 768;
-const PROJECTILE_SPAWN_OFFSET = 20;
+const PROJECTILE_SPAWN_OFFSET = 25;
 
 class Play extends Phaser.Scene {
   constructor() {

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from projectile import Projectile
 # Number of enemies spawned at game start
 ENEMY_SPAWN_COUNT = 6
 # Distance in pixels to spawn projectiles in front of the shooter
-PROJECTILE_SPAWN_OFFSET = 20
+PROJECTILE_SPAWN_OFFSET = 25
 
 
 class Game:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -36,7 +36,7 @@ const ENEMY_MAX_HEALTH = 10;
 const ENEMY_SPAWN_COUNT = 5;
 const REGEN_DELAY = 3000;
 const REGEN_INTERVAL = 1000;
-const PROJECTILE_SPAWN_OFFSET = 20;
+const PROJECTILE_SPAWN_OFFSET = 25;
 
 class Play extends Phaser.Scene {
   constructor() {


### PR DESCRIPTION
## Summary
- increase `PROJECTILE_SPAWN_OFFSET` so bullets spawn far enough from the player

## Testing
- `flake8`
- `pytest`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c2aff2f50832ab9520097daad03e0