### PR TITLE
Add player lives mechanic

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,6 +66,10 @@ class Game:
                 others = [self.player] + [o for o in self.enemies if o is not e]
                 e.update(others, self.projectiles)
                 e.draw(self.screen)
+
+            if self.player.health <= 0:
+                self.running = False
+                continue
             for p in self.projectiles[:]:
                 p.update()
                 p.draw(self.screen)

--- a/src/player.py
+++ b/src/player.py
@@ -2,6 +2,7 @@ import pygame
 
 # Player tuning constants
 PLAYER_MAX_HEALTH = 10
+PLAYER_MAX_LIVES = 10
 REGEN_DELAY_MS = 3000
 REGEN_INTERVAL_MS = 1000
 
@@ -18,6 +19,7 @@ class Player:
         self.rect.topleft = (x, y)
         # Allow the player to take damage like enemies
         self.health = PLAYER_MAX_HEALTH
+        self.lives = PLAYER_MAX_LIVES
         self.last_hit = pygame.time.get_ticks()
         self.last_regen = self.last_hit
 
@@ -26,6 +28,13 @@ class Player:
         self.health -= amount
         self.last_hit = pygame.time.get_ticks()
         self.last_regen = self.last_hit
+        if self.health <= 0:
+            if self.lives > 0:
+                self.lives -= 1
+                self.health = PLAYER_MAX_HEALTH
+                self.rect.topleft = (400, 300)
+            else:
+                self.health = 0
 
     def melee_attack(self, enemies) -> None:
         """Damage enemies within melee range."""


### PR DESCRIPTION
## Summary
- give players 10 lives via `PLAYER_MAX_LIVES`
- respawn player on damage when lives remain
- have Phaser enemies use `takeDamage` so player lives work
- exit the Pygame game loop when the player is out of lives

## Testing
- `flake8`
- `pytest`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c2fc97be0832abe48dc30adf46225