### PR TITLE
Add champion crown and visible health

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Smak Phaser</title>
+  <title>Smak</title>
   <style>
     body {
       margin: 0;
@@ -27,6 +27,9 @@
     h1 {
       margin: 10px 0 0;
       text-align: center;
+      font-size: 48px;
+      color: white;
+      text-shadow: 2px 2px 4px #000;
     }
   </style>
 </head>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -36,6 +36,9 @@ class Play extends Phaser.Scene {
     super('Play');
     this.enemies = null;
     this.projectiles = null;
+    this.healthGraphics = null;
+    this.champion = null;
+    this.crown = null;
   }
   create() {
     this.cursors = this.input.keyboard.createCursorKeys();
@@ -57,8 +60,11 @@ class Play extends Phaser.Scene {
       const ex = Phaser.Math.Between(50, GAME_WIDTH - 50);
       const ey = Phaser.Math.Between(50, GAME_HEIGHT - 50);
       const enemy = this.enemies.create(ex, ey, 'enemy');
+      enemy.setTint(Phaser.Display.Color.RandomRGB().color);
       enemy.health = 3;
     }
+
+    this.healthGraphics = this.add.graphics();
 
     this.projectiles = this.physics.add.group();
 
@@ -166,6 +172,42 @@ class Play extends Phaser.Scene {
         b.destroy();
       }
     }, this);
+
+    // Draw simple health bars on the right side
+    this.healthGraphics.clear();
+    const fighters = [this.player].concat(
+      this.enemies.getChildren().filter((e) => e.active),
+    );
+    fighters.forEach((f, idx) => {
+      const maxHp = f === this.player ? 5 : 3;
+      const barWidth = 100;
+      const barHeight = 10;
+      const x = GAME_WIDTH - barWidth - 10;
+      const y = 10 + idx * (barHeight + 10);
+      const tint = f.tintTopLeft || 0xffffff;
+      this.healthGraphics.fillStyle(0x500000, 1);
+      this.healthGraphics.fillRect(x, y, barWidth, barHeight);
+      this.healthGraphics.fillStyle(tint, 1);
+      this.healthGraphics.fillRect(
+        x,
+        y,
+        (barWidth * f.health) / maxHp,
+        barHeight,
+      );
+    });
+
+    if (!this.champion) {
+      const alive = fighters.filter((f) => f.active);
+      if (alive.length === 1) {
+        this.champion = alive[0];
+        this.crown = this.add.text(0, 0, '\uD83D\uDC51', {
+          fontSize: '32px',
+        }).setOrigin(0.5);
+      }
+    }
+    if (this.crown && this.champion && this.champion.active) {
+      this.crown.setPosition(this.champion.x, this.champion.y - 40);
+    }
   }
 }
 

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -22,9 +22,14 @@ class Enemy:
 
     def __init__(self, x: int, y: int) -> None:
         """Load the enemy sprite and position it on screen."""
-        # Create a red square sprite at runtime to avoid external files
+        # Use a unique color for each enemy so they appear as different fighters
+        self.color = (
+            random.randint(50, 255),
+            random.randint(50, 255),
+            random.randint(50, 255),
+        )
         self.image = pygame.Surface((32, 32), pygame.SRCALPHA)
-        self.image.fill((255, 0, 0))
+        self.image.fill(self.color)
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         self.speed = ENEMY_SPEED

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,8 @@
 
 import random
 import pygame
-from player import Player
-from enemy import Enemy
+from player import Player, PLAYER_MAX_HEALTH
+from enemy import Enemy, ENEMY_MAX_HEALTH
 from projectile import Projectile
 
 # Number of enemies spawned at game start
@@ -31,6 +31,10 @@ class Game:
         ]
         # List to hold active projectiles
         self.projectiles = []
+        # Fonts for UI elements
+        self.font = pygame.font.SysFont(None, 24)
+        self.crown_font = pygame.font.SysFont(None, 32)
+        self.champion = None
 
     def handle_events(self):
         """Process incoming events."""
@@ -93,6 +97,32 @@ class Game:
                         elif isinstance(t, Player) and t.health <= 0:
                             self.running = False
                         break
+            # Draw health bars along the left side
+            fighters = [self.player] + self.enemies
+            for idx, f in enumerate(fighters):
+                if f.health <= 0:
+                    continue
+                max_hp = PLAYER_MAX_HEALTH if isinstance(f, Player) else ENEMY_MAX_HEALTH
+                bar_width = 100
+                bar_height = 10
+                x = 10
+                y = 10 + idx * (bar_height + 10)
+                pygame.draw.rect(self.screen, (80, 0, 0), (x, y, bar_width, bar_height))
+                pygame.draw.rect(
+                    self.screen,
+                    (0, 200, 0),
+                    (x, y, int(bar_width * f.health / max_hp), bar_height),
+                )
+
+            # Determine champion and draw crown when one fighter remains
+            alive = [f for f in fighters if f.health > 0]
+            if len(alive) == 1 and self.champion is None:
+                self.champion = alive[0]
+            if self.champion and self.champion.health > 0:
+                crown = self.crown_font.render("\U0001F451", True, (255, 215, 0))
+                cx = self.champion.rect.centerx - crown.get_width() // 2
+                cy = self.champion.rect.top - 30
+                self.screen.blit(crown, (cx, cy))
             pygame.display.flip()
             self.clock.tick(60)
         # Clean shutdown when the loop exits.

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Smak Phaser</title>
+  <title>Smak</title>
   <style>
     body {
       margin: 0;
@@ -27,6 +27,9 @@
     h1 {
       margin: 10px 0 0;
       text-align: center;
+      font-size: 48px;
+      color: white;
+      text-shadow: 2px 2px 4px #000;
     }
   </style>
 </head>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -44,6 +44,9 @@ class Play extends Phaser.Scene {
     super('Play');
     this.enemies = null;
     this.projectiles = null;
+    this.healthGraphics = null;
+    this.champion = null;
+    this.crown = null;
   }
   create() {
     this.cursors = this.input.keyboard.createCursorKeys();
@@ -86,10 +89,13 @@ class Play extends Phaser.Scene {
       const ex = Phaser.Math.Between(50, GAME_WIDTH - 50);
       const ey = Phaser.Math.Between(50, GAME_HEIGHT - 50);
       const enemy = this.enemies.create(ex, ey, 'enemy');
+      enemy.setTint(Phaser.Display.Color.RandomRGB().color);
       enemy.health = ENEMY_MAX_HEALTH;
       enemy.lastHit = this.time.now;
       enemy.lastRegen = enemy.lastHit;
     }
+
+    this.healthGraphics = this.add.graphics();
 
     this.projectiles = this.physics.add.group();
 
@@ -232,6 +238,43 @@ class Play extends Phaser.Scene {
         b.destroy();
       }
     }, this);
+
+    // Draw health bars on the right side
+    this.healthGraphics.clear();
+    const fighters = [this.player].concat(
+      this.enemies.getChildren().filter((e) => e.active),
+    );
+    fighters.forEach((f, idx) => {
+      const maxHp = f === this.player ? PLAYER_MAX_HEALTH : ENEMY_MAX_HEALTH;
+      const barWidth = 100;
+      const barHeight = 10;
+      const x = GAME_WIDTH - barWidth - 10;
+      const y = 10 + idx * (barHeight + 10);
+      const tint = f.tintTopLeft || 0x00ff00;
+      this.healthGraphics.fillStyle(0x500000, 1);
+      this.healthGraphics.fillRect(x, y, barWidth, barHeight);
+      this.healthGraphics.fillStyle(tint, 1);
+      this.healthGraphics.fillRect(
+        x,
+        y,
+        (barWidth * f.health) / maxHp,
+        barHeight,
+      );
+    });
+
+    // Crown the remaining fighter when only one is left
+    if (!this.champion) {
+      const alive = fighters.filter((f) => f.active);
+      if (alive.length === 1) {
+        this.champion = alive[0];
+        this.crown = this.add.text(0, 0, '\uD83D\uDC51', {
+          fontSize: '32px',
+        }).setOrigin(0.5);
+      }
+    }
+    if (this.crown && this.champion && this.champion.active) {
+      this.crown.setPosition(this.champion.x, this.champion.y - 40);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- randomize enemy colors so each fighter looks unique
- display health bars for all fighters
- crown the final survivor with a crown emoji
- improve title style and update page title text

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests --colors`
- `python src/main.py` *(fails to open window but starts)*

------
https://chatgpt.com/codex/tasks/task_e_684c39518888832ab21fe907cefa77cc