### PR TITLE
Switch to projectile-only combat

### DIFF
--- a/src/enemy.py
+++ b/src/enemy.py
@@ -63,13 +63,6 @@ class Enemy:
         # Keep the enemy vertically within the screen bounds.
         self.rect.y = max(0, min(600 - self.rect.height, self.rect.y))
 
-        # Melee attack if in range
-        if self.rect.inflate(40, 40).colliderect(target.rect):
-            if hasattr(target, "take_damage"):
-                target.take_damage(1)
-            elif hasattr(target, "health"):
-                target.health -= 1
-
         # Occasionally fire a projectile at the target
         if random.random() < 0.01:
             dx = target.rect.centerx - self.rect.centerx

--- a/src/main.py
+++ b/src/main.py
@@ -44,9 +44,6 @@ class Game:
                 self.running = False
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_SPACE:
-                    # Melee attack damages nearby enemies
-                    self.player.melee_attack(self.enemies)
-                if event.key in (pygame.K_LSHIFT, pygame.K_RSHIFT):
                     x, y = self.player.rect.center
                     mx, my = pygame.mouse.get_pos()
                     dx = mx - x

--- a/src/player.py
+++ b/src/player.py
@@ -36,20 +36,6 @@ class Player:
             else:
                 self.health = 0
 
-    def melee_attack(self, enemies) -> None:
-        """Damage enemies within melee range."""
-        attack_rect = self.rect.inflate(40, 40)
-        for enemy in list(enemies):
-            if attack_rect.colliderect(enemy.rect):
-                if hasattr(enemy, "take_damage"):
-                    enemy.take_damage(1)
-                    if enemy.health <= 0:
-                        enemies.remove(enemy)
-                else:
-                    enemy.health -= 1
-                    if enemy.health <= 0:
-                        enemies.remove(enemy)
-
     def handle_input(self) -> None:
         """Handle keyboard input for movement with WASD."""
         keys = pygame.key.get_pressed()

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -56,7 +56,6 @@ class Play extends Phaser.Scene {
       down: Phaser.Input.Keyboard.KeyCodes.S,
       left: Phaser.Input.Keyboard.KeyCodes.A,
       right: Phaser.Input.Keyboard.KeyCodes.D,
-      shift: Phaser.Input.Keyboard.KeyCodes.SHIFT,
       space: Phaser.Input.Keyboard.KeyCodes.SPACE,
     });
 
@@ -144,18 +143,6 @@ class Play extends Phaser.Scene {
     this.player.setVelocity(vx, vy);
 
     if (Phaser.Input.Keyboard.JustDown(this.keys.space)) {
-      const range = 40;
-      this.enemies.children.each((enemy) => {
-        if (
-          enemy.active &&
-          Phaser.Math.Distance.Between(this.player.x, this.player.y, enemy.x, enemy.y) < range
-        ) {
-          this.hitEnemy({ destroy: () => {} }, enemy);
-        }
-      }, this);
-    }
-
-    if (Phaser.Input.Keyboard.JustDown(this.keys.shift)) {
       const pointer = this.input.activePointer;
       const angle = Phaser.Math.Angle.Between(
         this.player.x,
@@ -192,18 +179,6 @@ class Play extends Phaser.Scene {
         enemy.setVelocityX(-60);
       } else {
         enemy.setVelocityX(0);
-      }
-      if (Phaser.Math.Distance.Between(enemy.x, enemy.y, target.x, target.y) < 40) {
-        if (typeof target.takeDamage === 'function') {
-          target.takeDamage(1);
-        } else if (target.health !== undefined) {
-          target.health -= 1;
-          target.lastHit = this.time.now;
-          target.lastRegen = target.lastHit;
-          if (target.health <= 0) {
-            target.destroy();
-          }
-        }
       }
       if (Math.random() < 0.01) {
         const angle = Phaser.Math.Angle.Between(enemy.x, enemy.y, target.x, target.y);


### PR DESCRIPTION
## Summary
- remove melee attack logic in Pygame prototype
- remove melee attack logic in Phaser build and docs
- shoot projectiles with spacebar instead of shift

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`
- `SDL_VIDEODRIVER=dummy python src/main.py` *(quit via Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_684c49136d70832a996649604f0cdc39