### PR TITLE
Allow fighter class selection

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -5,18 +5,10 @@ class Boot extends Phaser.Scene {
     super('Boot');
   }
   preload() {
-    // Generate simple textures using graphics to avoid binary assets
+    FIGHTERS.forEach((f) => {
+      this.load.image(f, `assets/${f}`);
+    });
     const g = this.make.graphics({ x: 0, y: 0, add: false });
-    g.fillStyle(0x00ff00, 1);
-    g.fillRect(0, 0, 32, 32);
-    g.generateTexture('player', 32, 32);
-    g.clear();
-
-    g.fillStyle(0xff0000, 1);
-    g.fillRect(0, 0, 32, 32);
-    g.generateTexture('enemy', 32, 32);
-    g.clear();
-
     g.fillStyle(0xffff00, 1);
     g.fillRect(0, 0, 8, 8);
     g.generateTexture('projectile', 8, 8);
@@ -40,6 +32,17 @@ const REGEN_INTERVAL = 1000;
 const PROJECTILE_SPAWN_OFFSET = 25;
 const PROJECTILE_DAMAGE = 1;
 
+const FIGHTERS = [
+  'archer',
+  'axe-thrower',
+  'wizard',
+  'shield-bearer',
+  'demon',
+  'monk',
+];
+let playerClass = FIGHTERS[0];
+const SPRITE_SCALE = 0.0625;
+
 class Play extends Phaser.Scene {
   constructor() {
     super('Play');
@@ -62,8 +65,8 @@ class Play extends Phaser.Scene {
     this.player = this.physics.add.sprite(
       GAME_WIDTH / 2,
       GAME_HEIGHT / 2,
-      'player',
-    );
+      playerClass,
+    ).setScale(SPRITE_SCALE);
     this.player.setCollideWorldBounds(true);
     this.player.health = PLAYER_MAX_HEALTH;
     this.player.lives = PLAYER_MAX_LIVES;
@@ -85,11 +88,12 @@ class Play extends Phaser.Scene {
     };
 
     this.enemies = this.physics.add.group();
+    const enemyChoices = FIGHTERS.filter((f) => f !== playerClass);
     for (let i = 0; i < ENEMY_SPAWN_COUNT; i++) {
       const ex = Phaser.Math.Between(50, GAME_WIDTH - 50);
       const ey = Phaser.Math.Between(50, GAME_HEIGHT - 50);
-      const enemy = this.enemies.create(ex, ey, 'enemy');
-      enemy.setTint(Phaser.Display.Color.RandomRGB().color);
+      const type = Phaser.Utils.Array.GetRandom(enemyChoices);
+      const enemy = this.enemies.create(ex, ey, type).setScale(SPRITE_SCALE);
       enemy.health = ENEMY_MAX_HEALTH;
       enemy.lastHit = this.time.now;
       enemy.lastRegen = enemy.lastHit;
@@ -269,8 +273,21 @@ const config = {
 };
 let game = null;
 
+function chooseClass() {
+  const choice = window.prompt(
+    `Choose your fighter: ${FIGHTERS.join(', ')}`,
+    FIGHTERS[0],
+  );
+  if (choice && FIGHTERS.includes(choice)) {
+    playerClass = choice;
+  } else {
+    playerClass = FIGHTERS[0];
+  }
+}
+
 function startGame() {
   if (!game) {
+    chooseClass();
     game = new Phaser.Game(config);
   } else {
     game.scene.resume('Play');
@@ -293,6 +310,7 @@ function restartGame() {
     game.destroy(false);
     game = null;
   }
+  chooseClass();
   game = new Phaser.Game(config);
 }
 

--- a/src/enemy.py
+++ b/src/enemy.py
@@ -4,6 +4,9 @@ from typing import List, Protocol
 
 from projectile import Projectile
 
+# Sprite size for enemy images
+SPRITE_SIZE = (32, 32)
+
 # Tunable enemy constants
 ENEMY_SPEED = 2
 ENEMY_MAX_HEALTH = 10
@@ -20,16 +23,10 @@ class HasRect(Protocol):
 class Enemy:
     """Represents an enemy that moves toward the player."""
 
-    def __init__(self, x: int, y: int) -> None:
+    def __init__(self, x: int, y: int, fighter: str) -> None:
         """Load the enemy sprite and position it on screen."""
-        # Use a unique color for each enemy so they appear as different fighters
-        self.color = (
-            random.randint(50, 255),
-            random.randint(50, 255),
-            random.randint(50, 255),
-        )
-        self.image = pygame.Surface((32, 32), pygame.SRCALPHA)
-        self.image.fill(self.color)
+        raw = pygame.image.load(f"assets/{fighter}").convert_alpha()
+        self.image = pygame.transform.scale(raw, SPRITE_SIZE)
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         self.speed = ENEMY_SPEED

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,30 @@ ENEMY_SPAWN_COUNT = 6
 # Distance in pixels to spawn projectiles in front of the shooter
 PROJECTILE_SPAWN_OFFSET = 25
 
+# Available fighter classes
+FIGHTERS = [
+    "archer",
+    "axe-thrower",
+    "wizard",
+    "shield-bearer",
+    "demon",
+    "monk",
+]
+
+
+def choose_class() -> str:
+    """Prompt the user to choose a fighter class."""
+    print("Choose your fighter:")
+    for idx, f in enumerate(FIGHTERS, 1):
+        print(f"{idx}. {f}")
+    try:
+        choice = int(input("Enter number [1-6]: "))
+    except Exception:
+        choice = 1
+    if 1 <= choice <= len(FIGHTERS):
+        return FIGHTERS[choice - 1]
+    return FIGHTERS[0]
+
 
 class Game:
     """Encapsulates the game state and main loop."""
@@ -23,10 +47,16 @@ class Game:
         pygame.display.set_caption("SMaK")
         self.clock = pygame.time.Clock()
         self.running = True
-        self.player = Player(400, 300)
+        player_class = choose_class()
+        self.player = Player(400, 300, player_class)
+        enemy_choices = [c for c in FIGHTERS if c != player_class]
         # Spawn several enemies at random positions
         self.enemies = [
-            Enemy(random.randint(50, 750), random.randint(50, 550))
+            Enemy(
+                random.randint(50, 750),
+                random.randint(50, 550),
+                random.choice(enemy_choices),
+            )
             for _ in range(ENEMY_SPAWN_COUNT)
         ]
         # List to hold active projectiles

--- a/src/player.py
+++ b/src/player.py
@@ -1,5 +1,8 @@
 import pygame
 
+# Path to fighter sprite images
+SPRITE_SIZE = (32, 32)
+
 # Player tuning constants
 PLAYER_MAX_HEALTH = 10
 PLAYER_MAX_LIVES = 10
@@ -10,11 +13,10 @@ REGEN_INTERVAL_MS = 1000
 class Player:
     """Represents the player character."""
 
-    def __init__(self, x: int, y: int) -> None:
+    def __init__(self, x: int, y: int, fighter: str) -> None:
         """Load the player sprite and position it on screen."""
-        # Create a simple green square so no external assets are required
-        self.image = pygame.Surface((32, 32), pygame.SRCALPHA)
-        self.image.fill((0, 255, 0))
+        raw = pygame.image.load(f"assets/{fighter}").convert_alpha()
+        self.image = pygame.transform.scale(raw, SPRITE_SIZE)
         self.rect = self.image.get_rect()
         self.rect.topleft = (x, y)
         # Allow the player to take damage like enemies

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,18 +5,10 @@ class Boot extends Phaser.Scene {
     super('Boot');
   }
   preload() {
-    // Generate simple textures using graphics to avoid binary assets
+    FIGHTERS.forEach((f) => {
+      this.load.image(f, `assets/${f}`);
+    });
     const g = this.make.graphics({ x: 0, y: 0, add: false });
-    g.fillStyle(0x00ff00, 1);
-    g.fillRect(0, 0, 32, 32);
-    g.generateTexture('player', 32, 32);
-    g.clear();
-
-    g.fillStyle(0xff0000, 1);
-    g.fillRect(0, 0, 32, 32);
-    g.generateTexture('enemy', 32, 32);
-    g.clear();
-
     g.fillStyle(0xffff00, 1);
     g.fillRect(0, 0, 8, 8);
     g.generateTexture('projectile', 8, 8);
@@ -40,6 +32,17 @@ const REGEN_INTERVAL = 1000;
 const PROJECTILE_SPAWN_OFFSET = 25;
 const PROJECTILE_DAMAGE = 1;
 
+const FIGHTERS = [
+  'archer',
+  'axe-thrower',
+  'wizard',
+  'shield-bearer',
+  'demon',
+  'monk',
+];
+let playerClass = FIGHTERS[0];
+const SPRITE_SCALE = 0.0625;
+
 class Play extends Phaser.Scene {
   constructor() {
     super('Play');
@@ -62,8 +65,8 @@ class Play extends Phaser.Scene {
     this.player = this.physics.add.sprite(
       GAME_WIDTH / 2,
       GAME_HEIGHT / 2,
-      'player',
-    );
+      playerClass,
+    ).setScale(SPRITE_SCALE);
     this.player.setCollideWorldBounds(true);
     this.player.health = PLAYER_MAX_HEALTH;
     this.player.lives = PLAYER_MAX_LIVES;
@@ -85,11 +88,12 @@ class Play extends Phaser.Scene {
     };
 
     this.enemies = this.physics.add.group();
+    const enemyChoices = FIGHTERS.filter((f) => f !== playerClass);
     for (let i = 0; i < ENEMY_SPAWN_COUNT; i++) {
       const ex = Phaser.Math.Between(50, GAME_WIDTH - 50);
       const ey = Phaser.Math.Between(50, GAME_HEIGHT - 50);
-      const enemy = this.enemies.create(ex, ey, 'enemy');
-      enemy.setTint(Phaser.Display.Color.RandomRGB().color);
+      const type = Phaser.Utils.Array.GetRandom(enemyChoices);
+      const enemy = this.enemies.create(ex, ey, type).setScale(SPRITE_SCALE);
       enemy.health = ENEMY_MAX_HEALTH;
       enemy.lastHit = this.time.now;
       enemy.lastRegen = enemy.lastHit;
@@ -269,8 +273,21 @@ const config = {
 };
 let game = null;
 
+function chooseClass() {
+  const choice = window.prompt(
+    `Choose your fighter: ${FIGHTERS.join(', ')}`,
+    FIGHTERS[0],
+  );
+  if (choice && FIGHTERS.includes(choice)) {
+    playerClass = choice;
+  } else {
+    playerClass = FIGHTERS[0];
+  }
+}
+
 function startGame() {
   if (!game) {
+    chooseClass();
     game = new Phaser.Game(config);
   } else {
     game.scene.resume('Play');
@@ -293,6 +310,7 @@ function restartGame() {
     game.destroy(false);
     game = null;
   }
+  chooseClass();
   game = new Phaser.Game(config);
 }
 


### PR DESCRIPTION
## Summary
- let player pick their fighter class before the match
- show enemies using the remaining classes
- load fighter sprites for both the Pygame and Phaser builds

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`
- `echo 1 | SDL_VIDEODRIVER=dummy python src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684c4c9a76dc832abf1419e7440e41ab