### PR TITLE
Fix projectile collision freeze

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -108,8 +108,8 @@ class Play extends Phaser.Scene {
   }
   hitEnemy(bullet, enemy) {
     if (bullet.getData('owner') === enemy) return;
+    if (!enemy.active || !bullet.active) return;
     bullet.destroy();
-    if (!enemy.active) return;
     enemy.health -= PROJECTILE_DAMAGE;
     enemy.lastHit = this.time.now;
     enemy.lastRegen = enemy.lastHit;
@@ -119,8 +119,8 @@ class Play extends Phaser.Scene {
   }
   hitPlayer(bullet, player) {
     if (bullet.getData('owner') === player) return;
+    if (!player.active || !bullet.active) return;
     bullet.destroy();
-    if (!player.active) return;
     if (typeof player.takeDamage === 'function') {
       player.takeDamage(PROJECTILE_DAMAGE);
     } else {

--- a/src/main.py
+++ b/src/main.py
@@ -107,23 +107,32 @@ class Game:
                 if p.off_screen(800, 600):
                     self.projectiles.remove(p)
                     continue
+
                 targets = self.enemies[:] + [self.player]
+                hit = None
                 for t in targets:
                     if p.owner is t:
                         continue
                     if p.rect.colliderect(t.rect):
-                        if hasattr(t, "take_damage"):
-                            t.take_damage(PROJECTILE_DAMAGE)
-                        else:
-                            t.health -= PROJECTILE_DAMAGE
-                        if p in self.projectiles:
-                            self.projectiles.remove(p)
-                        if isinstance(t, Enemy) and t.health <= 0:
-                            if t in self.enemies:
-                                self.enemies.remove(t)
-                        elif isinstance(t, Player) and t.health <= 0:
-                            self.running = False
+                        hit = t
                         break
+
+                if hit is None:
+                    continue
+
+                if p in self.projectiles:
+                    self.projectiles.remove(p)
+
+                if hasattr(hit, "take_damage"):
+                    hit.take_damage(PROJECTILE_DAMAGE)
+                else:
+                    hit.health -= PROJECTILE_DAMAGE
+
+                if isinstance(hit, Enemy) and hit.health <= 0:
+                    if hit in self.enemies:
+                        self.enemies.remove(hit)
+                elif isinstance(hit, Player) and hit.health <= 0:
+                    self.running = False
             # Draw health bars along the left side
             fighters = [self.player] + self.enemies
             for idx, f in enumerate(fighters):

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -103,13 +103,25 @@ class Play extends Phaser.Scene {
 
     this.projectiles = this.physics.add.group();
 
-    this.physics.add.overlap(this.projectiles, this.enemies, this.hitEnemy, null, this);
-    this.physics.add.overlap(this.projectiles, this.player, this.hitPlayer, null, this);
+    this.physics.add.overlap(
+      this.projectiles,
+      this.enemies,
+      this.hitEnemy,
+      null,
+      this,
+    );
+    this.physics.add.overlap(
+      this.projectiles,
+      this.player,
+      this.hitPlayer,
+      null,
+      this,
+    );
   }
   hitEnemy(bullet, enemy) {
     if (bullet.getData('owner') === enemy) return;
+    if (!enemy.active || !bullet.active) return;
     bullet.destroy();
-    if (!enemy.active) return;
     enemy.health -= PROJECTILE_DAMAGE;
     enemy.lastHit = this.time.now;
     enemy.lastRegen = enemy.lastHit;
@@ -119,8 +131,8 @@ class Play extends Phaser.Scene {
   }
   hitPlayer(bullet, player) {
     if (bullet.getData('owner') === player) return;
+    if (!player.active || !bullet.active) return;
     bullet.destroy();
-    if (!player.active) return;
     if (typeof player.takeDamage === 'function') {
       player.takeDamage(PROJECTILE_DAMAGE);
     } else {


### PR DESCRIPTION
## Summary
- fix projectile hit logic so collisions cleanly exit
- ensure Phaser callback ignores inactive bullets and fighters

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c4f10b0d4832aa18f83cc64b6762d