### PR TITLE
Enforce fighter selection before entering board

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,23 @@
       margin-top: 10px;
       justify-content: center;
     }
+    #classSelect {
+      display: flex;
+      gap: 10px;
+      margin-top: 10px;
+      justify-content: center;
+    }
+    #classSelect label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      color: white;
+      font-size: 14px;
+    }
+    #classSelect img {
+      width: 32px;
+      height: 32px;
+    }
     h1 {
       margin: 10px 0 0;
       text-align: center;
@@ -37,12 +54,12 @@
   <h1>Smak</h1>
   <div id="classSelect">
     <span>Choose your fighter:</span>
-    <label><input type="radio" name="fighterClass" value="archer" checked> archer</label>
-    <label><input type="radio" name="fighterClass" value="axe-thrower"> axe-thrower</label>
-    <label><input type="radio" name="fighterClass" value="wizard"> wizard</label>
-    <label><input type="radio" name="fighterClass" value="shield-bearer"> shield-bearer</label>
-    <label><input type="radio" name="fighterClass" value="demon"> demon</label>
-    <label><input type="radio" name="fighterClass" value="monk"> monk</label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="archer"><img src="assets/fighter/archer.png" alt="archer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="axe-thrower"><img src="assets/fighter/axe-thrower.png" alt="axe-thrower"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="wizard"><img src="assets/fighter/wizard.png" alt="wizard"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="shield-bearer"><img src="assets/fighter/shield-bearer.png" alt="shield-bearer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="demon"><img src="assets/fighter/demon.png" alt="demon"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="monk"><img src="assets/fighter/monk.png" alt="monk"></label>
   </div>
   <div id="ui">
     <button id="startBtn">Start</button>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,23 @@
       margin-top: 10px;
       justify-content: center;
     }
+    #classSelect {
+      display: flex;
+      gap: 10px;
+      margin-top: 10px;
+      justify-content: center;
+    }
+    #classSelect label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      color: white;
+      font-size: 14px;
+    }
+    #classSelect img {
+      width: 32px;
+      height: 32px;
+    }
     h1 {
       margin: 10px 0 0;
       text-align: center;
@@ -37,12 +54,12 @@
   <h1>Smak</h1>
   <div id="classSelect">
     <span>Choose your fighter:</span>
-    <label><input type="radio" name="fighterClass" value="archer" checked> archer</label>
-    <label><input type="radio" name="fighterClass" value="axe-thrower"> axe-thrower</label>
-    <label><input type="radio" name="fighterClass" value="wizard"> wizard</label>
-    <label><input type="radio" name="fighterClass" value="shield-bearer"> shield-bearer</label>
-    <label><input type="radio" name="fighterClass" value="demon"> demon</label>
-    <label><input type="radio" name="fighterClass" value="monk"> monk</label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="archer"><img src="assets/fighter/archer.png" alt="archer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="axe-thrower"><img src="assets/fighter/axe-thrower.png" alt="axe-thrower"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="wizard"><img src="assets/fighter/wizard.png" alt="wizard"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="shield-bearer"><img src="assets/fighter/shield-bearer.png" alt="shield-bearer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="demon"><img src="assets/fighter/demon.png" alt="demon"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="monk"><img src="assets/fighter/monk.png" alt="monk"></label>
   </div>
   <div id="ui">
     <button id="startBtn">Start</button>

--- a/static/index.html
+++ b/static/index.html
@@ -24,6 +24,23 @@
       margin-top: 10px;
       justify-content: center;
     }
+    #classSelect {
+      display: flex;
+      gap: 10px;
+      margin-top: 10px;
+      justify-content: center;
+    }
+    #classSelect label {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      color: white;
+      font-size: 14px;
+    }
+    #classSelect img {
+      width: 32px;
+      height: 32px;
+    }
     h1 {
       margin: 10px 0 0;
       text-align: center;
@@ -35,6 +52,15 @@
 </head>
 <body>
   <h1>Smak</h1>
+  <div id="classSelect">
+    <span>Choose your fighter:</span>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="archer"><img src="assets/fighter/archer.png" alt="archer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="axe-thrower"><img src="assets/fighter/axe-thrower.png" alt="axe-thrower"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="wizard"><img src="assets/fighter/wizard.png" alt="wizard"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="shield-bearer"><img src="assets/fighter/shield-bearer.png" alt="shield-bearer"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="demon"><img src="assets/fighter/demon.png" alt="demon"></label>
+    <label class="fighter-option"><input type="radio" name="fighterClass" value="monk"><img src="assets/fighter/monk.png" alt="monk"></label>
+  </div>
   <div id="ui">
     <button id="startBtn">Start</button>
     <button id="pauseBtn">Pause</button>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -388,18 +388,20 @@ const config = {
 let game = null;
 
 function chooseClass() {
-  const inputs = document.querySelectorAll('input[name="fighterClass"]');
-  const selected = Array.from(inputs).find((i) => i.checked);
+  const selected = document.querySelector('input[name="fighterClass"]:checked');
   if (selected && FIGHTERS.includes(selected.value)) {
     playerClass = selected.value;
-  } else {
-    playerClass = FIGHTERS[0];
+    return true;
   }
+  return false;
 }
 
 function startGame() {
+  if (!chooseClass()) {
+    alert('Please choose a fighter class first.');
+    return;
+  }
   if (!game) {
-    chooseClass();
     game = new Phaser.Game(config);
   } else {
     game.scene.resume('Play');
@@ -430,6 +432,5 @@ window.addEventListener('load', () => {
   document.getElementById('startBtn').addEventListener('click', startGame);
   document.getElementById('pauseBtn').addEventListener('click', pauseGame);
   document.getElementById('restartBtn').addEventListener('click', restartGame);
-  // Initialize the game board immediately so the canvas is visible
-  startGame();
+  // Game will start when the user clicks the start button after choosing a class
 });


### PR DESCRIPTION
## Summary
- require selecting a fighter class before the Phaser game starts
- display fighter sprites when choosing a class

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c5989e8e8832a82aff8284bd73351