### PR TITLE
Fix gh-pages deploy permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_branch: gh-pages
           publish_dir: docs/
           keep_history: true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ GitHub Actions workflow automatically publishes this folder to the
 **GitHub Pages** to serve from the `gh-pages` branch and the game will be
 playable at:
 
+> **Note**: the workflow expects a repository secret named
+> `GH_PAGES_TOKEN` containing a personal access token with `repo` scope so
+> it can push updates to the `gh-pages` branch.
+
 <https://YOUR_GITHUB_USERNAME.github.io/smak>
 
 ## Repository Layout


### PR DESCRIPTION
## Summary
- deploy to GitHub Pages using personal token
- document the required `GH_PAGES_TOKEN` secret

## Testing
- `flake8 src/`
- `pytest --maxfail=1 --disable-warnings -q`
- `mypy`
- `npm run lint:js`
- `npx jest --ci --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684c5eba4128832aad98d5f2ea89c0fe