### PR TITLE
Fix WASD controls after restart

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -428,7 +428,9 @@ function restartGame() {
     }
     const newCanvas = document.createElement('canvas');
     newCanvas.id = 'gameCanvas';
+    newCanvas.tabIndex = 0;
     parent.appendChild(newCanvas);
+    newCanvas.focus();
     config.canvas = newCanvas;
     game = null;
   }

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
     <button id="pauseBtn">Pause</button>
     <button id="restartBtn">Restart</button>
   </div>
-  <canvas id="gameCanvas"></canvas>
+  <canvas id="gameCanvas" tabindex="0"></canvas>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.js"></script>
   <script src="docs/js/main.js"></script>
 </body>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -428,7 +428,9 @@ function restartGame() {
     }
     const newCanvas = document.createElement('canvas');
     newCanvas.id = 'gameCanvas';
+    newCanvas.tabIndex = 0;
     parent.appendChild(newCanvas);
+    newCanvas.focus();
     config.canvas = newCanvas;
     game = null;
   }


### PR DESCRIPTION
## Summary
- keep the canvas keyboard focus after a restart
- update Phaser restart logic so new canvas is focusable

## Testing
- `flake8`
- `pytest -q`
- `mypy`
- `eslint static/js`
- `npx jest --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684d9d0fe3d8832a868bd1fb892986d5