### PR TITLE
Fix freeze by caching skull surfaces

### DIFF
--- a/src/enemy.py
+++ b/src/enemy.py
@@ -83,6 +83,8 @@ class Enemy:
         self.last_hit = pygame.time.get_ticks()
         self.last_regen = self.last_hit
         self.agent = EnemyAgent(self)
+        font = pygame.font.SysFont(None, 32)
+        self.skull = font.render(SKULL_EMOJI, True, (255, 255, 255))
 
     def lose_life(self) -> None:
         """Remove a life and optionally respawn."""
@@ -113,8 +115,6 @@ class Enemy:
         """Draw the enemy to the given screen."""
         screen.blit(self.image, self.rect)
         if self.lives <= 0:
-            font = pygame.font.SysFont(None, 32)
-            skull = font.render(SKULL_EMOJI, True, (255, 255, 255))
-            x = self.rect.centerx - skull.get_width() // 2
+            x = self.rect.centerx - self.skull.get_width() // 2
             y = self.rect.top - 30
-            screen.blit(skull, (x, y))
+            screen.blit(self.skull, (x, y))

--- a/src/player.py
+++ b/src/player.py
@@ -26,6 +26,8 @@ class Player:
         self.lives = PLAYER_MAX_LIVES
         self.last_hit = pygame.time.get_ticks()
         self.last_regen = self.last_hit
+        font = pygame.font.SysFont(None, 32)
+        self.skull = font.render(SKULL_EMOJI, True, (255, 255, 255))
 
     def lose_life(self) -> None:
         """Remove a life and respawn or die."""
@@ -76,8 +78,6 @@ class Player:
         """Draw the player to the given screen."""
         screen.blit(self.image, self.rect)
         if self.lives <= 0:
-            font = pygame.font.SysFont(None, 32)
-            skull = font.render(SKULL_EMOJI, True, (255, 255, 255))
-            x = self.rect.centerx - skull.get_width() // 2
+            x = self.rect.centerx - self.skull.get_width() // 2
             y = self.rect.top - 30
-            screen.blit(skull, (x, y))
+            screen.blit(self.skull, (x, y))


### PR DESCRIPTION
## Summary
- cache skull icon surfaces in `Player` and `Enemy`
- reuse them in draw methods to avoid repeated font creation

## Testing
- `flake8`
- `pytest -q`
- `mypy src`
- `npx eslint static/js/main.js`
- `npx jest --runInBand --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684da134c464832ab1146f9f1ca3ff42