### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: docs/
-          keep_history: true
+          keep_files: false


### PR DESCRIPTION
## Summary
- use `github_token` instead of a custom secret
- remove deprecated `keep_history` input from deploy workflow

## Testing
- `flake8`
- `pytest --maxfail=1 --disable-warnings -q`
- `mypy`
- `npx eslint static/js`
- `npx jest --ci --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684dec6c3b24832aa7f49853e8bfadc8