### PR TITLE
Add end game popup

### DIFF
--- a/game.js
+++ b/game.js
@@ -4,6 +4,9 @@ const startBtn = document.getElementById('startBtn');
 const pauseBtn = document.getElementById('pauseBtn');
 const restartBtn = document.getElementById('restartBtn');
 const classSelect = document.getElementById('classSelect');
+const resultModal = document.getElementById('resultModal');
+const resultText = document.getElementById('resultText');
+const modalRestartBtn = document.getElementById('modalRestartBtn');
 
 const WIDTH = canvas.width;
 const HEIGHT = canvas.height;
@@ -86,6 +89,16 @@ let playerClass = 'wizard';
 let nextId = 0;
 let mouseX = WIDTH / 2;
 let mouseY = HEIGHT / 2;
+
+function showResults(winner) {
+  const msg = winner.isPlayer ? 'You are victorious!' : `${winner.cls} wins!`;
+  resultText.textContent = msg;
+  resultModal.style.display = 'flex';
+}
+
+function hideResults() {
+  resultModal.style.display = 'none';
+}
 
 function spawnFighters() {
   fighters = [];
@@ -226,6 +239,7 @@ function checkWinner() {
     winner.hasCrown = true;
     running = false;
     pauseBtn.textContent = 'Play';
+    showResults(winner);
   }
 }
 
@@ -263,6 +277,7 @@ startBtn.onclick = () => {
   startBtn.disabled = true;
   pauseBtn.disabled = false;
   restartBtn.disabled = false;
+  hideResults();
 };
 
 pauseBtn.onclick = () => {
@@ -274,6 +289,17 @@ restartBtn.onclick = () => {
   spawnFighters();
   running = true;
   pauseBtn.textContent = 'Pause';
+  hideResults();
+};
+
+modalRestartBtn.onclick = () => {
+  spawnFighters();
+  running = true;
+  pauseBtn.textContent = 'Pause';
+  startBtn.disabled = true;
+  pauseBtn.disabled = false;
+  restartBtn.disabled = false;
+  hideResults();
 };
 
 requestAnimationFrame(gameLoop);

--- a/index.html
+++ b/index.html
@@ -28,6 +28,14 @@
 </div>
 <p id="instructions">Use <strong>WASD</strong> to move, aim with your mouse, and shoot with <strong>space</strong> or left click. Hit <strong>Start</strong> to begin the battle.</p>
 <canvas id="gameCanvas" width="1200" height="900"></canvas>
+
+  <div id="resultModal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <p id="resultText"></p>
+      <button id="modalRestartBtn">Play Again</button>
+    </div>
+  </div>
+
 <script src="game.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -68,3 +68,23 @@ button:disabled {
   border: 2px solid #444;
   box-shadow: 0 0 10px #000 inset;
 }
+
+#resultModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#resultModal .modal-content {
+  background: #222;
+  padding: 20px 30px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px #000;
+}


### PR DESCRIPTION
## Summary
- add result modal markup and styles
- update game logic to show modal when the battle ends
- allow restarting from the modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e1cd1dbe0832ab1140b6bb73e9496