### PR TITLE
Enhance defeat messaging

### DIFF
--- a/game.js
+++ b/game.js
@@ -100,13 +100,18 @@ let mouseX = WIDTH / 2;
 let mouseY = HEIGHT / 2;
 
 function showResults(winner) {
-  const msg = winner.isPlayer ? 'You are victorious!' : `${winner.cls} wins!`;
+  const playerWon = winner.isPlayer;
+  const msg = playerWon
+    ? 'You are victorious!'
+    : `Defeat! You were slain by ${winner.cls}.`;
   resultText.textContent = msg;
+  resultText.className = playerWon ? 'win-text' : 'lose-text';
   resultModal.style.display = 'flex';
 }
 
 function hideResults() {
   resultModal.style.display = 'none';
+  resultText.className = '';
 }
 
 function spawnFighters() {

--- a/style.css
+++ b/style.css
@@ -88,3 +88,16 @@ button:disabled {
   border-radius: 8px;
   box-shadow: 0 0 10px #000;
 }
+
+#resultText {
+  font-size: 32px;
+  margin-bottom: 20px;
+}
+
+.win-text {
+  color: #d4af37;
+}
+
+.lose-text {
+  color: #f44336;
+}


### PR DESCRIPTION
## Summary
- clarify the end game message when losing
- style result text with win/lose colours

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684f0382e590832aa17154c827ab7afc